### PR TITLE
fix connecting from dataconsole

### DIFF
--- a/kubernetes/pingdatagov-service.yaml
+++ b/kubernetes/pingdatagov-service.yaml
@@ -10,13 +10,14 @@ metadata:
   name: pingdatagov
 spec:
   ports:
-  - name: "4443"
-    port: 4443
+  # - name: "4443"
+  #   port: 4443
+  #   targetPort: 443
+  - name: "443"
+    port: 443
     targetPort: 443
-  - name: "2636"
-    port: 2636
+  - name: "636"
+    port: 636
     targetPort: 636
   selector:
     io.kompose.service: pingdatagov
-status:
-  loadBalancer: {}

--- a/kubernetes/pingdirectory-service.yaml
+++ b/kubernetes/pingdirectory-service.yaml
@@ -13,16 +13,14 @@ spec:
   - name: "389"
     port: 389
     targetPort: 389
-  - name: "1636"
-    port: 1636
+  - name: "636"
+    port: 636
     targetPort: 636
   - name: "443"
     port: 443
     targetPort: 443
-  - name: "2443"
-    port: 2443
-    targetPort: 2443
+  # - name: "2443"
+  #   port: 2443
+  #   targetPort: 2443
   selector:
     io.kompose.service: pingdirectory
-status:
-  loadBalancer: {}


### PR DESCRIPTION
dataconsole likes connecting to 636, so we should expose this on the service. Otherwise users need to put something like `pingdirectory:1636` in "Server" on data console. 

I left the other ports as comments if you wanted two service ports to point to the same target port for some reason. note, this isn't a recommended pattern. 